### PR TITLE
Fix: do not insert an extra space in formatted numbers

### DIFF
--- a/lib/global_phone/number.rb
+++ b/lib/global_phone/number.rb
@@ -81,7 +81,8 @@ module GlobalPhone
 
         prefix = prefix.gsub("$NP", national_prefix)
         prefix = prefix.gsub("$FG", match[1])
-        result = "#{prefix} #{match[2]}"
+
+        result = "#{prefix}#{match[2]}"
       end
 
       def national_prefix_formatting_rule

--- a/test/edge_test.rb
+++ b/test/edge_test.rb
@@ -15,7 +15,7 @@ module GlobalPhone
       # We don't include those formats in our database, so we fall
       # back to the closest match.
       number = context.parse("1520123456", "IE")
-      assert_equal "1520  123 456", number.national_format
+      assert_equal "1520 123 456", number.national_format
     end
   end
 end


### PR DESCRIPTION
When we generate the national format for a given phone number, the output format is specified by the global_phone.json database.

For example, New Zealand is `$1-$2 $3` where:
* `$1` is the national prefix, 
* `$2` is the first group of digits
* `$3` is the last group of digits.

However, when the national prefix is added to the number, we are erroneously inserting an extra space between the NP and the first group.  For NZ, this results in `09 -123 1234`, and for other countries it results in a double space: `02  1234 1234`.
Since the spacing is included in the format specified by the DB, we should not need to add any additional spacing here.