### PR TITLE
Add the semaphore gem packaging.

### DIFF
--- a/.semaphore/publish.yml
+++ b/.semaphore/publish.yml
@@ -1,0 +1,33 @@
+version: v1.0
+name: Publish Gem
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Publish
+    run:
+      when: "branch = 'master'"
+    task:
+      secrets:
+        - name: github-token
+      prologue:
+        commands:
+          - checkout
+          - cache restore
+          - sem-version ruby 2.6.5
+          - source ~/github-token-env
+          - gem install keycutter
+          - "mkdir -p ~/.gem/"
+          - 'echo ":github: Bearer $GITHUB_PKG_TOKEN" > ~/.gem/credentials'
+          - 'chmod g=-,o=- ~/.gem/credentials' # gem complains if credentials are world-readable.
+          - bundle config set path vendor/bundle
+          - bundle config set rubygems.pkg.github.com callrail-semaphore-access:$GITHUB_PKG_TOKEN
+          - bundle config set --local gem.push_key github
+          - bundle install
+          - cache store
+      jobs:
+        - name: 'Publish Gem'
+          commands:
+            - checkout
+            - bundle exec rake publish

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,14 @@
+version: v1.0
+name: Protoman
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: 'Publish gem'
+    run:
+      when: branch = 'master' and change_in(['../lib/global_phone/version.rb'])"
+    task:
+      jobs:
+				- name: Publish new version
+					pipeline_file: publish.yml

--- a/Rakefile
+++ b/Rakefile
@@ -13,3 +13,12 @@ task :gems do
     system "gem build #{gemspec}"
   end
 end
+
+# build is a bundler-defined task
+desc 'publish a new version of the gem to Github Packages'
+task publish: :build do
+  gem = "pkg/global_phone-#{GlobalPhone::VERSION}.gem"
+  puts "Pushing #{gem} to Github Packages..."
+  puts `gem push --key github --host https://rubygems.pkg.github.com/callrail '#{gem}'`
+  exit($?.exitstatus)
+end

--- a/global_phone.gemspec
+++ b/global_phone.gemspec
@@ -14,4 +14,11 @@ Gem::Specification.new do |s|
   s.authors = ["Sam Stephenson"]
   s.email = ["sstephenson@gmail.com"]
   s.homepage = "https://github.com/sstephenson/global_phone"
+
+  if s.respond_to?(:metadata)
+    s.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/callrail'
+    s.metadata["homepage_uri"] = s.homepage
+  else
+    raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
+  end
 end

--- a/lib/global_phone.rb
+++ b/lib/global_phone.rb
@@ -1,8 +1,7 @@
 require 'global_phone/context'
+require 'global_phone/version'
 
 module GlobalPhone
-  VERSION = '1.0.1'
-
   class Error < ::StandardError; end
   class NoDatabaseError < Error; end
 

--- a/lib/global_phone/version.rb
+++ b/lib/global_phone/version.rb
@@ -1,0 +1,3 @@
+module GlobalPhone
+  VERSION = '1.0.2'
+end


### PR DESCRIPTION
https://callrail.tpondemand.com/entity/37014-move-phonenumber-class-into-telephony-gem

This PR adds the a semaphore config to package this gem in the private callrail gem repository. There was not a semaphore config previously, so we probably need to add specs so that we have a proper CI environment.